### PR TITLE
Add substitute for ES::Messaging::Reader

### DIFF
--- a/lib/event_store/messaging/message/message__ref.rb
+++ b/lib/event_store/messaging/message/message__ref.rb
@@ -1,1 +1,0 @@
-/Users/sbellware/projects/obsidian/event-store-messaging/lib/event_store/messaging/message.rb

--- a/lib/event_store/messaging/reader.rb
+++ b/lib/event_store/messaging/reader.rb
@@ -11,14 +11,12 @@ module EventStore
 
         dependency :dispatcher, EventStore::Messaging::Dispatcher
 
-        def initialize(reader)
-          @reader = reader
+        def initialize
           @messages = []
         end
 
         def self.build
-          reader = Messaging::Reader.new "substituteStream"
-          new reader
+          new
         end
 
         def add(message)

--- a/lib/event_store/messaging/reader.rb
+++ b/lib/event_store/messaging/reader.rb
@@ -4,6 +4,36 @@ module EventStore
       def self.http_reader
         Client::HTTP::Reader
       end
+
+      class Substitute
+        attr_reader :messages
+        attr_reader :reader
+
+        dependency :dispatcher, EventStore::Messaging::Dispatcher
+
+        def initialize(reader)
+          @reader = reader
+          @messages = []
+        end
+
+        def self.build
+          reader = Messaging::Reader.new "substituteStream"
+          new reader
+        end
+
+        def add(message)
+          messages << message
+        end
+
+        def start(&supplementary_action)
+          messages.each_with_index do |message, index|
+            number = index + 1
+            event_data = OpenStruct.new :number => number
+            dispatcher.dispatch message, event_data
+            supplementary_action.(message, event_data) if supplementary_action
+          end
+        end
+      end
     end
   end
 end

--- a/lib/event_store/messaging/reader.rb
+++ b/lib/event_store/messaging/reader.rb
@@ -7,7 +7,6 @@ module EventStore
 
       class Substitute
         attr_reader :messages
-        attr_reader :reader
 
         dependency :dispatcher, EventStore::Messaging::Dispatcher
 


### PR DESCRIPTION
I am using this to test projections in isolation.