### PR TITLE
Remove session as dependency of message reader

### DIFF
--- a/lib/event_store/messaging/message_reader.rb
+++ b/lib/event_store/messaging/message_reader.rb
@@ -6,7 +6,6 @@ module EventStore
       dependency :reader, EventStore::Client::HTTP::EventReader
       dependency :dispatcher, EventStore::Messaging::Dispatcher
       dependency :logger, Telemetry::Logger
-      dependency :session, EventStore::Client::HTTP::Session
 
       def starting_position
         @starting_position ||= 0
@@ -24,13 +23,11 @@ module EventStore
 
       def self.build(stream_name, dispatcher, starting_position: nil, slice_size: nil, session: nil)
         logger.trace "Building message reader"
-        session ||= EventStore::Client::HTTP::Session.build
 
         new(stream_name, starting_position, slice_size).tap do |instance|
           http_reader.configure instance, stream_name, starting_position: starting_position, slice_size: slice_size, session: session
           Telemetry::Logger.configure instance
 
-          instance.session = session if session
           instance.dispatcher = dispatcher
 
           logger.debug "Built message reader"

--- a/test/bench/client_integration/expected_version.rb
+++ b/test/bench/client_integration/expected_version.rb
@@ -17,12 +17,9 @@ context "Writing the Expected Version Number" do
 
   context "Wrong Version" do
     test "Fails" do
-      begin
-        writer.write message_2, stream_name, expected_version: 11
-      rescue EventStore::Client::HTTP::Request::Post::ExpectedVersionError => error
+      assert proc { writer.write message_2, stream_name, expected_version: 11 } do
+        raises_error? EventStore::Client::HTTP::Request::Post::ExpectedVersionError
       end
-
-      assert error
     end
   end
 end

--- a/test/bench/client_integration/write_initial.rb
+++ b/test/bench/client_integration/write_initial.rb
@@ -23,12 +23,9 @@ context "Initial Event" do
     writer.write message, stream_name
 
     test "Is an error" do
-      begin
-        writer.write_initial message, stream_name
-      rescue EventStore::Client::HTTP::Request::Post::ExpectedVersionError => error
+      assert proc { writer.write_initial message, stream_name } do
+        raises_error? EventStore::Client::HTTP::Request::Post::ExpectedVersionError
       end
-
-      assert error
     end
   end
 end

--- a/test/bench/message/copy/strictness.rb
+++ b/test/bench/message/copy/strictness.rb
@@ -16,12 +16,9 @@ context "Message Copying Strictness" do
       receiver = EventStore::Messaging::Controls::Message::FewerAttributesMessage.new
 
       test "Is an error" do
-        begin
-          EventStore::Messaging::Message::Copy.(source, receiver)
-        rescue EventStore::Messaging::Message::Copy::Error => error
+        assert proc { EventStore::Messaging::Message::Copy.(source, receiver) } do
+          raises_error? EventStore::Messaging::Message::Copy::Error
         end
-
-        assert error
       end
     end
   end

--- a/test/bench/message/proceed/strictness.rb
+++ b/test/bench/message/proceed/strictness.rb
@@ -16,12 +16,9 @@ context "Proceed from Previous Message and Copy Message Attributes with Strictne
       receiver = EventStore::Messaging::Controls::Message::FewerAttributesMessage.new
 
       test "Is an error" do
-        begin
-          EventStore::Messaging::Message::Proceed.(source, receiver, copy: true)
-        rescue EventStore::Messaging::Message::Copy::Error => error
+        assert proc { EventStore::Messaging::Message::Proceed.(source, receiver, copy: true) } do
+          raises_error? EventStore::Messaging::Message::Copy::Error
         end
-
-        assert error
       end
     end
   end

--- a/test/bench/registry.rb
+++ b/test/bench/registry.rb
@@ -15,12 +15,9 @@ context "Registry" do
     item = Object.new
     registry.register item
 
-    begin
-      registry.register item
-    rescue EventStore::Messaging::Registry::Error => error
+    assert proc { registry.register item } do
+      raises_error? EventStore::Messaging::Registry::Error
     end
-
-    assert error
   end
 
   test "Optional, specialized work is done after registration" do


### PR DESCRIPTION
Also, I hunted down some old uses of the manual error testing and updated them to the test-bench way.